### PR TITLE
More build improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "08:00"
+      timezone: Europe/London
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "sata"
+      - "sata-form3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  tag:
+    name: Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        with:
+          fetch-depth: 0
+      - name: Conventional Changelog Action
+        uses: TriPSs/conventional-changelog-action@64b6a5db055a91612ec02cd77ea24a23e3437f12 # v3.11.0
+        with:
+          github-token: ${{ secrets.github_token }}
+  goreleaser:
+    name: Release
+    needs: tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v3.1.0
+        with:
+          go-version: 1.18
+      - name: GoReleaser release
+        uses: goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b # v2.9.1
+        with:
+          distribution: goreleaser
+          version: v1.9.1
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v3.1.0
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       - name: lint
-        uses: magefile/mage-action@v1
+        uses: magefile/mage-action@0a2bfd2ca891da3552ae39be755aecdce60ed1bc # v1.7.0
         with:
           version: latest
           args: lint
       - name: test
-        uses: magefile/mage-action@v1
+        uses: magefile/mage-action@0a2bfd2ca891da3552ae39be755aecdce60ed1bc # v1.7.0
         with:
           version: latest
           args: test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,4 @@
+builds:
+- skip: true
+release:
+  prerelease: auto


### PR DESCRIPTION
- Release on merges with conventional commit message tags.
- Pin GitHub Actions to commit hashes rather than tags.
- Introduce dependabot
- Introduce goreleaser