### PR TITLE
feat: Add support for basic authentication

### DIFF
--- a/pkg/server/handler_info_refs.go
+++ b/pkg/server/handler_info_refs.go
@@ -17,6 +17,12 @@ func (s *Server) GetInfoRefs(respWriter http.ResponseWriter, req *http.Request) 
 		return
 	}
 
+	if err := s.authenticate(req.BasicAuth()); err != nil {
+		http.Error(respWriter, "invalid auth", http.StatusUnauthorized)
+
+		return
+	}
+
 	// see Smart Clients section in
 	// https://github.com/git/git/blob/master/Documentation/technical/http-protocol.txt
 	vals := req.URL.Query()

--- a/pkg/server/handler_receive_pack.go
+++ b/pkg/server/handler_receive_pack.go
@@ -17,6 +17,12 @@ func (s *Server) GetReceivePack(respWriter http.ResponseWriter, req *http.Reques
 		return
 	}
 
+	if err := s.authenticate(req.BasicAuth()); err != nil {
+		http.Error(respWriter, "invalid auth", http.StatusUnauthorized)
+
+		return
+	}
+
 	if err := validateContentType(req, transport.ReceivePackServiceName); err != nil {
 		http.Error(respWriter, err.Error(), http.StatusBadRequest)
 

--- a/pkg/server/handler_upload_pack.go
+++ b/pkg/server/handler_upload_pack.go
@@ -18,6 +18,12 @@ func (s *Server) GetUploadPack(respWriter http.ResponseWriter, req *http.Request
 		return
 	}
 
+	if err := s.authenticate(req.BasicAuth()); err != nil {
+		http.Error(respWriter, "invalid auth", http.StatusUnauthorized)
+
+		return
+	}
+
 	if err := validateContentType(req, transport.UploadPackServiceName); err != nil {
 		http.Error(respWriter, err.Error(), http.StatusBadRequest)
 

--- a/pkg/server/helper_test.go
+++ b/pkg/server/helper_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -8,8 +9,13 @@ import (
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	gitfs "github.com/go-git/go-git/v5/storage/filesystem"
 	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/sata-form3/go-git-http-backend/pkg/server"
 	"github.com/stretchr/testify/require"
 )
 
@@ -67,4 +73,70 @@ func repoWithInitCommit(t *testing.T, name, content string) *git.Repository {
 	require.NoError(t, err)
 
 	return repo
+}
+
+type cloneAssert struct {
+	t *testing.T
+
+	url string
+
+	auth server.BasicAuth
+}
+
+type cloneAssertOption func(*cloneAssert)
+
+func newCloneAssert(t *testing.T, url string, opts ...cloneAssertOption) *cloneAssert {
+	t.Helper()
+
+	cloneAssert := &cloneAssert{
+		t: t,
+
+		url: url,
+
+		auth: server.BasicAuth{
+			Username: "",
+			Password: "",
+		},
+	}
+
+	for _, opt := range opts {
+		opt(cloneAssert)
+	}
+
+	return cloneAssert
+}
+
+func withAuth(auth server.BasicAuth) cloneAssertOption {
+	return func(c *cloneAssert) {
+		c.auth = auth
+	}
+}
+
+func (c *cloneAssert) assert(filename, content string) {
+	c.t.Helper()
+
+	storage := gitfs.NewStorage(memfs.New(), cache.NewObjectLRUDefault())
+	opts := &git.CloneOptions{
+		Auth: &http.BasicAuth{
+			Username: c.auth.Username,
+			Password: c.auth.Password,
+		},
+		URL:           c.url,
+		RemoteName:    "origin",
+		ReferenceName: plumbing.NewBranchReferenceName("master"),
+		SingleBranch:  false,
+		Depth:         0,
+	}
+
+	repo, err := git.CloneContext(context.Background(), storage, memfs.New(), opts)
+	require.NoError(c.t, err)
+	require.NotEmpty(c.t, repo)
+
+	wt, err := repo.Worktree()
+	require.NoError(c.t, err)
+
+	fs := wt.Filesystem
+	readContent := readFile(c.t, fs, filename)
+
+	require.Equal(c.t, content, readContent, "content mismatch")
 }

--- a/pkg/server/httptest.go
+++ b/pkg/server/httptest.go
@@ -15,8 +15,8 @@ type HTTPTestServer struct {
 
 // NewHTTPTest initialises a new Git Server as well as a HTTP test
 // server which is started.
-func NewHTTPTest(repo *git.Repository, owner, repoName string) (*HTTPTestServer, error) {
-	server, err := New(repo, owner, repoName)
+func NewHTTPTest(repo *git.Repository, owner, repoName string, opts ...Option) (*HTTPTestServer, error) {
+	server, err := New(repo, owner, repoName, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Provide a way to configure basic authentication for the server as well
as passing it through the httptest layer via the options pattern.

Closes #8